### PR TITLE
Replaced Accelerator link returns 404.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ A healthy run would have `G`, `MSG`, `D`, `MSD` with values hovering between `0`
 
 ## Multi-GPU Training
 
-The `GigaGAN` class is now equipped with <a href="https://huggingface.co/docs/accelerate/accelerator">🤗 Accelerator</a>. You can easily do multi-gpu training in two steps using their `accelerate` CLI
+The `GigaGAN` class is now equipped with <a href="https://huggingface.co/docs/accelerate/en/package_reference/accelerator">🤗 Accelerator</a>. You can easily do multi-gpu training in two steps using their `accelerate` CLI
 
 At the project root directory, where the training script is, run
 


### PR DESCRIPTION
It looks like the old link pointed to the old HF Accelerator page which now 404s. I've updated the link to point to the current Accelerator page.